### PR TITLE
Prevent `Google.Protobuf.ByteString.CopyFrom()` from erasing files.

### DIFF
--- a/src/openiap.cs
+++ b/src/openiap.cs
@@ -356,7 +356,10 @@ public class openiap {
                 });
         }
         foreach(var f in wi.Files) {
-            f.File = Google.Protobuf.ByteString.CopyFrom();
+            if (Google.Protobuf.ByteString.CopyFrom() is Google.Protobuf.ByteString bs && bs.Length > 0)
+            {
+                f.File = bs;
+            }
         }
         var any = Any.Pack(pwir, UpdateWorkitemRequest.Descriptor.FullName);
         var envelope = new Envelope() { Command = "updateworkitem", Data = any };


### PR DESCRIPTION
But perhaps the line is just wrong and CopyFrom should have an argument or be left out?
But in any case this commit prevents replacing files with empty bytestrings.